### PR TITLE
Change default welcome text locales (ca/es)

### DIFF
--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1,0 +1,6 @@
+ca:
+  decidim:
+    pages:
+      home:
+        hero:
+          welcome: Benvingut/da al %{organization}!

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,0 +1,6 @@
+es:
+  decidim:
+    pages:
+      home:
+        hero:
+          welcome: Bienvenido/a al %{organization}!


### PR DESCRIPTION
#### :tophat: What? Why?
> Per defecte, el Decidim col·loca el ‘Benvingut/da a’ i el ‘!’ del final, s’hauria de poder afegir una ‘L’, per tal que fos ‘Benvingut/da al’ Consell

The default text only shows if a welcome text has not yet been provided.
https://github.com/decidim/decidim/blob/a867cedde4ebb81f8923e03793a636ed4c042c30/decidim-core/app/cells/decidim/content_blocks/hero/show.erb#L6

### :camera: Screenshots
#### /admin/organization/homepage/content_blocks/hero/edit
![welcome_text](https://user-images.githubusercontent.com/40306853/51331629-730bdb80-1a7a-11e9-9c05-36bbdc42696b.png)
#### Catala
![benvinguda](https://user-images.githubusercontent.com/40306853/51331643-7901bc80-1a7a-11e9-81d9-e4d8f5f61c08.png)
#### Castellano
![bienvenida](https://user-images.githubusercontent.com/40306853/51331631-743d0880-1a7a-11e9-8635-3b3ad3f1769a.png)