### PR TITLE
Force ransack gem version to fix undefined method 'polymorphic?'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,11 @@ gem 'whenever'
 gem 'openssl'
 gem 'figaro', '>= 1.1.1'
 
+# Force gem version to fix:
+# undefined method `polymorphic?' for ActiveRecord::Reflection::PolymorphicReflection
+# See: https://github.com/activerecord-hackery/ransack/issues/1039
+gem 'ransack', '2.1.1'
+
 gem 'decidim', DECIDIM_VERSION
 
 gem 'decidim-verifications-barcelona_energia_census', git: "https://github.com/CodiTramuntana/decidim-verifications-barcelona_energia_census.git", tag: "v0.2.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -547,8 +547,6 @@ GEM
     pg_search (2.3.0)
       activerecord (>= 4.2)
       activesupport (>= 4.2)
-    polyamorous (2.3.0)
-      activerecord (>= 5.0)
     powerpack (0.1.2)
     premailer (1.11.1)
       addressable
@@ -598,12 +596,11 @@ GEM
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
     rake (12.3.3)
-    ransack (2.3.0)
+    ransack (2.1.1)
       actionpack (>= 5.0)
       activerecord (>= 5.0)
       activesupport (>= 5.0)
       i18n
-      polyamorous (= 2.3.0)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -779,6 +776,7 @@ DEPENDENCIES
   listen (~> 3.1.0)
   openssl
   puma (~> 3.0)
+  ransack (= 2.1.1)
   spring
   spring-watcher-listen (~> 2.0.0)
   uglifier (>= 1.3.0)


### PR DESCRIPTION
Force ransack gem version to fix:
`undefined method 'polymorphic?' for ActiveRecord::Reflection::PolymorphicReflection`

See: https://github.com/activerecord-hackery/ransack/issues/1039