### PR TITLE
Remove parent assemblies block

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'rails', '< 6'
 gem 'openssl'
 gem 'figaro', '>= 1.1.1'
 gem "wicked_pdf"
+gem 'deface'
 
 gem 'decidim', DECIDIM_VERSION
 gem 'decidim-consultations', DECIDIM_VERSION

--- a/app/overrides/remove_public_parent_assemblies.rb
+++ b/app/overrides/remove_public_parent_assemblies.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Deface::Override.new(virtual_path: 'decidim/assemblies/assemblies/index',
+                     name: 'remove_public_parent_assemblies',
+                     remove: "erb[loud]:contains('parent_assemblies')",
+                     original: "<%= render partial: 'helper_method' %>")


### PR DESCRIPTION
The parent assemblies block have been removed with the Deface gem.

![Captura de pantalla de 2021-04-14 13-44-19](https://user-images.githubusercontent.com/75725233/114705639-3944e080-9d28-11eb-94d0-3ea0b00097ec.png)
